### PR TITLE
Make power sensor reflect current state of relay

### DIFF
--- a/custom_components/ebeco/sensor.py
+++ b/custom_components/ebeco/sensor.py
@@ -109,10 +109,17 @@ class EbecoPowerSensor(EbecoEntity, SensorEntity):
         """Return the installed effect in Watts."""
         return self._device["installedEffect"]
 
+    def is_on(self) -> bool:
+        """Return the state of the relay."""
+        return self._device["relayOn"] is True
+
     @property
     def native_value(self) -> StateType:
         """Return the state of the entity."""
-        return self.installed_effect
+        if self.is_on():
+            return self.installed_effect
+
+        return 0
 
 
 class EbecoEnergySensor(EbecoEntity, SensorEntity):


### PR DESCRIPTION
The API returns the installed effect, which the power sensor
previously returned as a fixed value. As the API also exposes
the current state of the relay, the sensor should be dynamic.
This fixes #9.