### PR TITLE
Fix updating target temperature from integration

### DIFF
--- a/custom_components/ebeco/__init__.py
+++ b/custom_components/ebeco/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(hass, entry):
         try:
             if await device.async_change(change):
                 data = await device.get_device()
-                await coordinator.async_set_updated_data(data)
+                coordinator.async_set_updated_data(data)
         except Exception:
             _LOGGER.exception("Failed to apply changes to thermostat")
             return False

--- a/custom_components/ebeco/ebeco_device.py
+++ b/custom_components/ebeco/ebeco_device.py
@@ -63,9 +63,7 @@ class EbecoDevice:
             "temperatureSet": temperature,
         }
 
-        await self._ebeco_data_handler.set_room_target_temperature(
-            self._device_id, json_data
-        )
+        await self._ebeco_data_handler.set_room_target_temperature(json_data)
 
         self._device["powerOn"] = heating_enabled
         self._device["temperatureSet"] = temperature


### PR DESCRIPTION
Apparently HomeAssistant has several methods prefixed with `async_` that are actually not `async`.
And I refactored a bit too much without really testing everything afterwards, so passed along too much data.

This fixes #10 