### PR TITLE
Add decimal support to sensors

### DIFF
--- a/custom_components/ebeco/sensor.py
+++ b/custom_components/ebeco/sensor.py
@@ -260,5 +260,9 @@ class EbecoTemperatureSensor(EbecoEntity, SensorEntity):
 
     @property
     def native_value(self) -> StateType:
-        """Return the state of the entity."""
-        return self._device[f"temperature{self._sensor}"]
+        """Return the state of the entity with decimals."""
+        key = f"temperature{self._sensor}"
+        key_decimals = f"{key}Decimals"
+        if key_decimals in self._device:
+            return self._device[key_decimals]
+        return self._device[key]


### PR DESCRIPTION
This PR adds decimal support to sensors. 

Previously, the decimal support was only added to the climate component:
https://github.com/joggs/home_assistant_ebeco/pull/36

Fixes this issue:
https://github.com/joggs/home_assistant_ebeco/pull/36#issuecomment-2473318265